### PR TITLE
add facebook to social icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,20 @@
       <div class="row" style="clear: left;">
         <div class="col-md-4 col-sm-6">
           <h4 class="heading">Connect with us!</h4>
-          <p class="social social--small"><a href="https://github.com/OSDLabs" data-animate-hover="pulse" class="external facebook" target="_blank"><i class="fa fa-github"></i></a><a href="http://bitsgoacodes.slack.com/signup" data-animate-hover="pulse" class="external facebook" target="_blank"><i class="fa fa-slack"></i></a><a href="mailto:mail@osdlabs.org" data-animate-hover="pulse" class="email" target="_blank"><i class="fa fa-envelope"></i></a></p>
+          <p class="social social--small">
+            <a href="https://github.com/OSDLabs" data-animate-hover="pulse" class="external facebook" target="_blank">
+              <i class="fa fa-github"></i>
+            </a>
+            <a href="http://bitsgoacodes.slack.com/signup" data-animate-hover="pulse" class="external facebook" target="_blank">
+              <i class="fa fa-slack"></i>
+            </a>
+            <a href="http://facebook.com/osdlabs" data-animate-hover="pulse" class="external facebook" target="_blank">
+              <i class="fa fa-facebook"></i>
+            </a>
+            <a href="mailto:mail@osdlabs.org" data-animate-hover="pulse" class="email" target="_blank">
+              <i class="fa fa-envelope"></i>
+            </a>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added Facebook to the social icons displayed under the main body image, between slack and email (third from left). Also reorganised the code for that paragraph with indentation.